### PR TITLE
refactor: rename Dialog into Modal

### DIFF
--- a/packages/client/src/components/Panel/Panel.tsx
+++ b/packages/client/src/components/Panel/Panel.tsx
@@ -2,12 +2,12 @@ import React from "react";
 
 import { IconClose } from "..";
 import {
-	Dialog,
-	DialogClose,
-	DialogContent,
-	DialogDescription,
-	DialogHeading,
-} from "../private/Dialog/Dialog";
+	Modal,
+	ModalClose,
+	ModalContent,
+	ModalDescription,
+	ModalHeading,
+} from "../private/Modal/Modal";
 
 export const Panel = ({
 	open,
@@ -21,19 +21,19 @@ export const Panel = ({
 	children: React.ReactNode;
 }) => {
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="flex h-full min-h-[95%] w-full flex-col bg-slate-500 sm:h-auto sm:min-h-[10rem] sm:w-[95%] sm:rounded-lg sm:border sm:border-slate-200/10 md:max-w-2xl">
-				<DialogHeading className="flex flex-row-reverse justify-between p-4 text-xl font-bold">
-					<DialogClose>
+		<Modal open={open} onOpenChange={onOpenChange}>
+			<ModalContent className="flex h-full min-h-[95%] w-full flex-col bg-slate-500 sm:h-auto sm:min-h-[10rem] sm:w-[95%] sm:rounded-lg sm:border sm:border-slate-200/10 md:max-w-2xl">
+				<ModalHeading className="flex flex-row-reverse justify-between p-4 text-xl font-bold">
+					<ModalClose>
 						<IconClose />
-					</DialogClose>
+					</ModalClose>
 					<div>{title}</div>
-				</DialogHeading>
+				</ModalHeading>
 
-				<DialogDescription className="flex flex-grow flex-col p-2 sm:p-4">
+				<ModalDescription className="flex flex-grow flex-col p-2 sm:p-4">
 					{children}
-				</DialogDescription>
-			</DialogContent>
-		</Dialog>
+				</ModalDescription>
+			</ModalContent>
+		</Modal>
 	);
 };

--- a/packages/client/src/components/private/Dialog/DialogContext.tsx
+++ b/packages/client/src/components/private/Dialog/DialogContext.tsx
@@ -1,5 +1,0 @@
-import * as React from "react";
-
-import type { ContextType } from "./DialogTypes";
-
-export const DialogContext = React.createContext<ContextType>(null);

--- a/packages/client/src/components/private/Modal/Modal.tsx
+++ b/packages/client/src/components/private/Modal/Modal.tsx
@@ -5,42 +5,44 @@ import {
 	useId,
 	useMergeRefs,
 } from "@floating-ui/react";
+import clsx from "clsx";
 import * as React from "react";
 
 import { ButtonIcon } from "../..";
 import type { ButtonProps } from "../../Button/ButtonTypes";
-import { DialogContext } from "./DialogContext";
-import { useDialog, useDialogContext } from "./DialogHooks";
-import type { DialogOptions } from "./DialogTypes";
+import { ModalContext } from "./ModalContext";
+import { useModal, useModalContext } from "./ModalHooks";
+import type { ModalOptions } from "./ModalTypes";
 
-export function Dialog({
+export function Modal({
 	children,
 	...options
 }: {
 	children: React.ReactNode;
-} & DialogOptions) {
-	const dialog = useDialog(options);
+} & ModalOptions) {
+	const dialog = useModal(options);
 	return (
-		<DialogContext.Provider value={dialog}>{children}</DialogContext.Provider>
+		<ModalContext.Provider value={dialog}>{children}</ModalContext.Provider>
 	);
 }
 
 type overlayBackgroundProps = {
 	overlayBackground?: string;
 };
-export const DialogContent = React.forwardRef<
+export const ModalContent = React.forwardRef<
 	HTMLDivElement,
 	React.HTMLProps<HTMLDivElement> & overlayBackgroundProps
->(function DialogContent(props, propRef) {
-	const { context: floatingContext, ...context } = useDialogContext();
+>(function ModalContent(props, propRef) {
+	const { context: floatingContext, ...context } = useModalContext();
 	const ref = useMergeRefs([context.refs.setFloating, propRef]);
 
 	if (!floatingContext.open) return null;
 
 	const { overlayBackground, ...rest } = props;
-	const overlayClass = overlayBackground
-		? `grid place-items-center ${overlayBackground}`
-		: "grid place-items-center bg-black sm:bg-black/[.8]";
+	const overlayClass = clsx("grid place-items-center", {
+		[`${overlayBackground}`]: overlayBackground,
+		"bg-black sm:bg-black/[.8]": !overlayBackground,
+	});
 
 	return (
 		<FloatingPortal>
@@ -60,14 +62,14 @@ export const DialogContent = React.forwardRef<
 	);
 });
 
-export const DialogHeading = React.forwardRef<
+export const ModalHeading = React.forwardRef<
 	HTMLHeadingElement,
 	React.HTMLProps<HTMLHeadingElement>
->(function DialogHeading({ children, ...props }, ref) {
-	const { setLabelId } = useDialogContext();
+>(function ModalHeading({ children, ...props }, ref) {
+	const { setLabelId } = useModalContext();
 	const id = useId();
 
-	// Only sets `aria-labelledby` on the Dialog root element
+	// Only sets `aria-labelledby` on the Modal root element
 	// if this component is mounted inside it.
 	React.useLayoutEffect(() => {
 		setLabelId(id);
@@ -81,14 +83,14 @@ export const DialogHeading = React.forwardRef<
 	);
 });
 
-export const DialogDescription = React.forwardRef<
+export const ModalDescription = React.forwardRef<
 	HTMLParagraphElement,
 	React.HTMLProps<HTMLParagraphElement>
->(function DialogDescription({ children, ...props }, ref) {
-	const { setDescriptionId } = useDialogContext();
+>(function ModalDescription({ children, ...props }, ref) {
+	const { setDescriptionId } = useModalContext();
 	const id = useId();
 
-	// Only sets `aria-describedby` on the Dialog root element
+	// Only sets `aria-describedby` on the Modal root element
 	// if this component is mounted inside it.
 	React.useLayoutEffect(() => {
 		setDescriptionId(id);
@@ -102,11 +104,11 @@ export const DialogDescription = React.forwardRef<
 	);
 });
 
-export const DialogClose = React.forwardRef<
+export const ModalClose = React.forwardRef<
 	HTMLButtonElement & ButtonProps,
 	ButtonProps
->(function DialogClose(props, ref) {
-	const { setOpen } = useDialogContext();
+>(function ModalClose(props, ref) {
+	const { setOpen } = useModalContext();
 	const { children, ...rest } = props;
 	return (
 		<ButtonIcon

--- a/packages/client/src/components/private/Modal/ModalContext.tsx
+++ b/packages/client/src/components/private/Modal/ModalContext.tsx
@@ -1,0 +1,5 @@
+import * as React from "react";
+
+import type { ContextType } from "./ModalTypes";
+
+export const ModalContext = React.createContext<ContextType>(null);

--- a/packages/client/src/components/private/Modal/ModalHooks.tsx
+++ b/packages/client/src/components/private/Modal/ModalHooks.tsx
@@ -7,14 +7,14 @@ import {
 } from "@floating-ui/react";
 import * as React from "react";
 
-import { DialogContext } from "./DialogContext";
-import type { DialogOptions } from "./DialogTypes";
+import { ModalContext } from "./ModalContext";
+import type { ModalOptions } from "./ModalTypes";
 
-export function useDialog({
+export function useModal({
 	initialOpen = false,
 	open: controlledOpen,
 	onOpenChange: setControlledOpen,
-}: DialogOptions = {}) {
+}: ModalOptions = {}) {
 	const [uncontrolledOpen, setUncontrolledOpen] = React.useState(initialOpen);
 	const [labelId, setLabelId] = React.useState<string | undefined>();
 	const [descriptionId, setDescriptionId] = React.useState<
@@ -57,11 +57,11 @@ export function useDialog({
 	);
 }
 
-export const useDialogContext = () => {
-	const context = React.useContext(DialogContext);
+export const useModalContext = () => {
+	const context = React.useContext(ModalContext);
 
 	if (context == null) {
-		throw new Error("Dialog components must be wrapped in <Dialog />");
+		throw new Error("Modal components must be wrapped in <Modal />");
 	}
 
 	return context;

--- a/packages/client/src/components/private/Modal/ModalTypes.d.ts
+++ b/packages/client/src/components/private/Modal/ModalTypes.d.ts
@@ -1,13 +1,13 @@
-import { useDialog } from "./DialogHooks";
+import { useModal } from "./ModalHooks";
 
-export interface DialogOptions {
+export interface ModalOptions {
 	initialOpen?: boolean;
 	open?: boolean;
 	onOpenChange?: (open: boolean) => void;
 }
 
 export type ContextType =
-	| (ReturnType<typeof useDialog> & {
+	| (ReturnType<typeof useModal> & {
 			setLabelId: React.Dispatch<React.SetStateAction<string | undefined>>;
 			setDescriptionId: React.Dispatch<
 				React.SetStateAction<string | undefined>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: The software's dialog components have been renamed and refactored as modal components to better reflect their purpose. This includes changes to component names, context, and associated hooks. This change is part of an ongoing effort to improve the clarity and consistency of our codebase.
- Improvement: The `overlayBackground` property in `ModalContent` is now optional, providing more flexibility in the design of modals.
- Improvement: The `overlayClass` in `ModalContent` now uses the `clsx` library for more efficient handling of conditional class names, leading to smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->