### PR TITLE
fix: remove unused noHeader prop

### DIFF
--- a/packages/client/src/common/types.d.ts
+++ b/packages/client/src/common/types.d.ts
@@ -69,10 +69,6 @@ export type AppContextProps = {
 	dispatch: React.Dispatch<ActionProps>;
 };
 
-export type MessagesContainerProps = {
-	noHeader?: boolean;
-};
-
 export type MessageAssistantProps = {
 	children?: string;
 	name?: string;

--- a/packages/client/src/modules/Messages/MessagesContainer.tsx
+++ b/packages/client/src/modules/Messages/MessagesContainer.tsx
@@ -8,16 +8,13 @@ import {
 	ROLE_INTERNAL,
 	ROLE_USER,
 } from "../../common/constants";
-import type { MessagesContainerProps } from "../../common/types";
 import { isDev } from "../../common/utilities";
 import { MessagesContainerHeader, PromptInput, Toolbox } from "..";
 import { AppContext } from "../App/AppContext";
 
 const MessageAssistant = lazy(() => import("../Messages/MessageAssistant"));
 
-export const MessagesContainer = ({
-	noHeader = false,
-}: MessagesContainerProps) => {
+export const MessagesContainer = () => {
 	const smoothScrollRef: React.RefObject<HTMLDivElement> = useRef(null);
 
 	const { isAuthenticated } = useAuth0();
@@ -65,7 +62,7 @@ export const MessagesContainer = ({
 	return (
 		<>
 			<div className={containerClass}>
-				{!noHeader && <MessagesContainerHeader />}
+				<MessagesContainerHeader />
 
 				{state &&
 					state.messages.length > 0 &&


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the Messages interface by removing unnecessary properties.
	- The Messages container now consistently displays its header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->