### PR TITLE
fix: history table is too wide in some cases on small devices

### DIFF
--- a/packages/client/src/modules/History/HistoryContent.tsx
+++ b/packages/client/src/modules/History/HistoryContent.tsx
@@ -120,7 +120,7 @@ const renderAsTable = (
 							>
 								{item.timestamp}
 							</TableCell>
-							<TableCell className="text-white">
+							<TableCell className="max-w-[100px] text-white sm:max-w-full">
 								{extractFirstUserMessage(item.messages)}
 							</TableCell>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated styling for the table cell width in the History section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->