### PR TITLE
fix: bump dependencies to latest

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,8 +24,8 @@
 	},
 	"dependencies": {
 		"@auth0/auth0-react": "2.2.4",
-		"@floating-ui/react": "0.26.9",
-		"@versini/ui-components": "5.14.3",
+		"@floating-ui/react": "0.26.12",
+		"@versini/ui-components": "5.14.4",
 		"@versini/ui-form": "1.2.0",
 		"@versini/ui-icons": "1.5.0",
 		"@versini/ui-system": "1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,11 +27,11 @@ importers:
         specifier: 2.2.4
         version: 2.2.4(react-dom@18.2.0)(react@18.2.0)
       '@floating-ui/react':
-        specifier: 0.26.9
-        version: 0.26.9(react-dom@18.2.0)(react@18.2.0)
+        specifier: 0.26.12
+        version: 0.26.12(react-dom@18.2.0)(react@18.2.0)
       '@versini/ui-components':
-        specifier: 5.14.3
-        version: 5.14.3(@floating-ui/react@0.26.9)(fast-equals@5.0.1)(micro-memoize@4.1.2)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 5.14.4
+        version: 5.14.4(@floating-ui/react@0.26.12)(fast-equals@5.0.1)(micro-memoize@4.1.2)(react-dom@18.2.0)(react@18.2.0)
       '@versini/ui-form':
         specifier: 1.2.0
         version: 1.2.0(react-dom@18.2.0)(react@18.2.0)
@@ -643,6 +643,19 @@ packages:
       '@floating-ui/dom': 1.6.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@floating-ui/react@0.26.12(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-D09o62HrWdIkstF2kGekIKAC0/N/Dl6wo3CQsnLcOmO3LkW6Ik8uIb3kw8JYkwxNCcg+uJ2bpWUiIijTBep05w==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0)(react@18.2.0)
+      '@floating-ui/utils': 0.2.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tabbable: 6.2.0
     dev: false
 
   /@floating-ui/react@0.26.9(react-dom@18.2.0)(react@18.2.0):
@@ -2272,20 +2285,20 @@ packages:
       eslint: 8.57.0
     dev: true
 
-  /@versini/ui-components@5.14.3(@floating-ui/react@0.26.9)(fast-equals@5.0.1)(micro-memoize@4.1.2)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-YdQmHdX0ESGF/y1PCbXbp3QGd7uFBKodgobOYS4q3ZFlozsxeLuThmTNMQ6cq2adbPlvvvsaX5k28iEhCaelAQ==}
+  /@versini/ui-components@5.14.4(@floating-ui/react@0.26.12)(fast-equals@5.0.1)(micro-memoize@4.1.2)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-k50xphytOf4WF0fj+4oFUU6MRzKlYxLcdwHxWGtqh1TGDLZkSrWq9OjYqURVYIX8HLVZpZsl6EdbIf+j5ZSrKA==}
     peerDependencies:
-      '@floating-ui/react': <=0.26.9
+      '@floating-ui/react': 0.26.12
       fast-equals: 5.0.1
       micro-memoize: 4.1.2
       react: ^18.2.0
       react-dom: ^18.2.0
     dependencies:
-      '@floating-ui/react': 0.26.9(react-dom@18.2.0)(react@18.2.0)
+      '@floating-ui/react': 0.26.12(react-dom@18.2.0)(react@18.2.0)
       '@tailwindcss/typography': 0.5.12(tailwindcss@3.4.3)
       '@versini/ui-hooks': 2.2.0(react-dom@18.2.0)(react@18.2.0)
       '@versini/ui-icons': 1.5.0(react-dom@18.2.0)(react@18.2.0)
-      '@versini/ui-private': 1.4.1(react-dom@18.2.0)(react@18.2.0)
+      '@versini/ui-private': 1.4.2(react-dom@18.2.0)(react@18.2.0)
       clsx: 2.1.0
       fast-equals: 5.0.1
       micro-memoize: 4.1.2
@@ -2350,6 +2363,19 @@ packages:
       react-dom: ^18.2.0
     dependencies:
       '@floating-ui/react': 0.26.9(react-dom@18.2.0)(react@18.2.0)
+      '@versini/ui-hooks': 2.2.0(react-dom@18.2.0)(react@18.2.0)
+      clsx: 2.1.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@versini/ui-private@1.4.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-sOYtjEbjy9F06MBCIetgQwHQVPTTFnNLGwG3VXwh2JKGvjGrCRc+0R0fcPgAwen2iw/zjVcnE/ta+6PAeMEb/A==}
+    peerDependencies:
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    dependencies:
+      '@floating-ui/react': 0.26.12(react-dom@18.2.0)(react@18.2.0)
       '@versini/ui-hooks': 2.2.0(react-dom@18.2.0)(react@18.2.0)
       clsx: 2.1.0
       react: 18.2.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependencies for improved performance and compatibility:
		- `@floating-ui/react` version updated from `0.26.9` to `0.26.12`.
		- `@versini/ui-components` version updated from `5.14.3` to `5.14.4`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->