### PR TITLE
fix: no need to reset search field on delete chat anymore

### DIFF
--- a/packages/client/src/modules/History/HistoryContent.tsx
+++ b/packages/client/src/modules/History/HistoryContent.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from "@versini/ui-form";
 import { useLocalStorage } from "@versini/ui-hooks";
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 
 import {
 	ACTION_SEARCH,
@@ -50,7 +50,6 @@ export const HistoryContent = ({
 	}>({
 		data: fullHistory,
 	});
-	const inputRef = useRef<HTMLInputElement>(null);
 	const { dispatch } = useContext(AppContext);
 
 	const endUser = isDev
@@ -92,7 +91,6 @@ export const HistoryContent = ({
 						<TextInput
 							defaultValue={historyState.searchString}
 							focusMode="light"
-							ref={inputRef}
 							name="Search"
 							label="Search"
 							onChange={onSearchChange}
@@ -106,7 +104,6 @@ export const HistoryContent = ({
 							setFullHistory={setFullHistory}
 							dispatch={dispatch}
 							onOpenChange={onOpenChange}
-							inputRef={inputRef}
 							endUser={endUser}
 						/>
 					</div>

--- a/packages/client/src/modules/History/HistoryTable.tsx
+++ b/packages/client/src/modules/History/HistoryTable.tsx
@@ -74,7 +74,6 @@ const onClickDelete = async (
 	item: { id: any },
 	setFilteredHistory: (arg0: any) => void,
 	setFullHistory: (arg0: any) => void,
-	inputRef: any,
 	endUser: any,
 ) => {
 	try {
@@ -89,9 +88,6 @@ const onClickDelete = async (
 			const data = await response.json();
 			setFullHistory(data.data.deleteChat);
 			setFilteredHistory({ data: data.data.deleteChat });
-			if (inputRef?.current) {
-				inputRef.current.value = "";
-			}
 		}
 	} catch (error) {
 		// nothing to declare officer
@@ -109,13 +105,11 @@ export const HistoryTable = ({
 	setFullHistory,
 	dispatch,
 	onOpenChange,
-	inputRef,
 	endUser,
 }: {
 	dispatch: any;
 	endUser: any;
 	filteredHistory: any;
-	inputRef: any;
 	onOpenChange: any;
 	setFilteredHistory: any;
 	setFullHistory: any;
@@ -249,7 +243,6 @@ export const HistoryTable = ({
 												item,
 												setFilteredHistory,
 												setFullHistory,
-												inputRef,
 												endUser,
 											);
 										}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the `HistoryContent` component to enhance handling of input references and context usage.
	- Modified the `onClickDelete` function in `HistoryTable` to improve interaction by not resetting input fields directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->