### PR TITLE
fix: disabled reset history filter button when there is no filter

### DIFF
--- a/packages/client/src/modules/History/HistoryContent.tsx
+++ b/packages/client/src/modules/History/HistoryContent.tsx
@@ -104,7 +104,8 @@ export const HistoryContent = ({
 							spacing={{ t: 2, b: 2 }}
 							rightElement={
 								<Button
-									mode="light"
+									disabled={!historyState.searchString}
+									mode="dark"
 									noBorder
 									size="small"
 									onClick={() => {

--- a/packages/client/src/modules/History/HistoryTable.tsx
+++ b/packages/client/src/modules/History/HistoryTable.tsx
@@ -238,7 +238,6 @@ export const HistoryTable = ({
 				</TableHead>
 				<TableBody>
 					{data.map((item: HistoryItemProps, idx: any) => {
-						// biome-ignore lint/correctness/useJsxKeyInIterable: This is a table, the key is the row
 						return item?.messages?.length > 0 ? (
 							<TableRow key={`${CARDS.HISTORY.TITLE}-${item.id}-${idx}`}>
 								{isWide && <TableCell>{idx + 1}</TableCell>}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the History content display to be disabled when no search string is provided.

- **Code Quality**
  - Removed unnecessary comments related to linting and correctness in the History table component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->