### PR TITLE
feat: hide "reset" history filter button when there is no filter

### DIFF
--- a/packages/client/src/modules/History/HistoryContent.tsx
+++ b/packages/client/src/modules/History/HistoryContent.tsx
@@ -102,22 +102,25 @@ export const HistoryContent = ({
 							label="Search"
 							onChange={onSearchChange}
 							spacing={{ t: 2, b: 2 }}
-							rightElement={
-								<Button
-									disabled={!historyState.searchString}
-									mode="dark"
-									noBorder
-									size="small"
-									onClick={() => {
-										updateDataOnSearch("");
-										if (inputRef.current?.value) {
-											inputRef.current.value = "";
-										}
-									}}
-								>
-									Reset
-								</Button>
-							}
+							{...(historyState.searchString && {
+								rightElement: (
+									<Button
+										disabled={!historyState.searchString}
+										mode="dark"
+										noBorder
+										size="small"
+										onClick={() => {
+											updateDataOnSearch("");
+											if (inputRef.current?.value) {
+												inputRef.current.value = "";
+												inputRef.current.focus();
+											}
+										}}
+									>
+										Reset
+									</Button>
+								),
+							})}
 						/>
 					</form>
 					<div className="flex flex-col gap-2 sm:flex-row">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved "Reset" button functionality in the History section:
    - The button is now conditionally rendered based on the search input.
    - The input field is automatically focused after resetting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->