### PR TITLE
fix: do not try to get basic location over and over

### DIFF
--- a/packages/client/src/modules/App/App.tsx
+++ b/packages/client/src/modules/App/App.tsx
@@ -21,6 +21,7 @@ import { AppContext, HistoryContext } from "./AppContext";
 import { historyReducer, reducer } from "./reducer";
 
 function App({ isComponent = false }: { isComponent?: boolean }) {
+	const loadingBasicLocationRef = useRef(false);
 	const loadingDetailedLocationRef = useRef(false);
 	const loadingServerStatsRef = useRef(false);
 	const { isAuthenticated, getAccessToken } = useAuth();
@@ -107,10 +108,18 @@ function App({ isComponent = false }: { isComponent?: boolean }) {
 		}
 
 		/**
+		 * We already tried to fetch the location, no need to try again.
+		 */
+		if (loadingBasicLocationRef.current) {
+			return;
+		}
+
+		/**
 		 * If we do not have the location cached in local storage,
 		 * or the accuracy is 0, we need to request for the location.
 		 */
 		if (!cachedLocation || cachedLocation.accuracy === 0) {
+			loadingBasicLocationRef.current = true;
 			(async () => {
 				const location = await getCurrentGeoLocation();
 				setCachedLocation(location);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a `loadingBasicLocationRef` to the `App` component to prevent repeated attempts to fetch the basic location.
- Implemented an early return if `loadingBasicLocationRef` is already true, ensuring that the location fetch is not attempted multiple times unnecessarily.
- Set `loadingBasicLocationRef` to true before initiating the location fetch to mark the operation as in progress.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Prevent repeated attempts to fetch basic location in App component</code></dd></summary>
<hr>

packages/client/src/modules/App/App.tsx

<li>Added a <code>loadingBasicLocationRef</code> to prevent repeated location fetch <br>attempts.<br> <li> Included a check to return early if <code>loadingBasicLocationRef</code> is true.<br> <li> Set <code>loadingBasicLocationRef</code> to true before attempting to fetch <br>location.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/sassysaint-ui/pull/540/files#diff-7a4ed8327abd700adb491edb0b708087a1056caf669041dc50690838a2646257">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

