### PR TITLE
fix: if there are no chats, stats should not be 0ms but N/A

### DIFF
--- a/packages/client/src/common/utilities.tsx
+++ b/packages/client/src/common/utilities.tsx
@@ -198,10 +198,12 @@ export const numberFormatter = new Intl.NumberFormat("en", {
 });
 
 export const durationFormatter = (value: number) => {
-	return prettyMilliseconds(value, {
-		secondsDecimalDigits: 2,
-		unitCount: 2,
-	});
+	return value > 0
+		? prettyMilliseconds(value, {
+				secondsDecimalDigits: 2,
+				unitCount: 2,
+			})
+		: "N/A";
 };
 
 export const getMessageContaintWrapperClass = (isAuthenticated?: boolean) => {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Modified the `durationFormatter` function to return "N/A" instead of "0ms" when there are no chats.
- Added a conditional check in `durationFormatter` to determine if the value is greater than 0.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utilities.tsx</strong><dd><code>Fix durationFormatter to handle no chats scenario</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/client/src/common/utilities.tsx

<li>Modified <code>durationFormatter</code> to return "N/A" instead of "0ms" when there <br>are no chats.<br> <li> Added a conditional check to determine if the value is greater than 0.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/aversini/sassysaint-ui/pull/554/files#diff-7485864690e7c4c17a960c20da6be7e0deb939964279c880734e7f6b56a9230a">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

