### PR TITLE
fix: wrong version for component - oops

### DIFF
--- a/packages/component/src/components/SassySaint/SassySaint.tsx
+++ b/packages/component/src/components/SassySaint/SassySaint.tsx
@@ -5,4 +5,4 @@ export type SassySaintProps = {
 export const SassySaint = ({ domain }: SassySaintProps) => {
 	return <AppBootstrap isComponent={true} domain={domain} />;
 };
-SassySaint.displayName = "SassySaint-4.0.1";
+SassySaint.displayName = "SassySaint-4.0.0";


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Corrected the `displayName` version in the `SassySaint` component from "SassySaint-4.0.1" to "SassySaint-4.0.0" to reflect the accurate version.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SassySaint.tsx</strong><dd><code>Fix incorrect displayName version in SassySaint component</code></dd></summary>
<hr>

packages/component/src/components/SassySaint/SassySaint.tsx

<li>Corrected the <code>displayName</code> version from "SassySaint-4.0.1" to <br>"SassySaint-4.0.0".<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/sassysaint-ui/pull/560/files#diff-feb342ea966ac05731227a16eeab1cb4c8d3e128ef89b9eb464fc9519c03efb4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

