### PR TITLE
chore: trying to link versions of both packages - take 2

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,17 @@
 {
 	"packages": {
-		"packages/client": {},
-		"packages/component": {}
+		"packages/client": {
+			"component": "client"
+		},
+		"packages/component": {
+			"component": "component"
+		}
 	},
 	"plugins": [
 		{
-			"type": "linked-versions"
+			"type": "linked-versions",
+			"groupName": "sassysaint",
+			"components": ["client", "component"]
 		}
 	]
 }


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated `release-please-config.json` to link versions of `client` and `component` packages.
- Added `groupName` as `sassysaint` to manage linked versions.
- Defined components array to specify linked packages.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-please-config.json</strong><dd><code>Update package linking and group configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

release-please-config.json

<li>Added <code>component</code> field to both <code>client</code> and <code>component</code> packages.<br> <li> Introduced <code>groupName</code> as <code>sassysaint</code> under plugins.<br> <li> Defined <code>components</code> array with <code>client</code> and <code>component</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/aversini/sassysaint-ui/pull/567/files#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2b">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

